### PR TITLE
Make `finish` wait until the connection is actually finished.

### DIFF
--- a/src/Database/PostgreSQL/LibPQ/Internal.hs
+++ b/src/Database/PostgreSQL/LibPQ/Internal.hs
@@ -23,15 +23,16 @@ import Foreign
 -- | 'Connection' encapsulates a connection to the backend.
 data Connection = Conn {-# UNPACK #-} !(ForeignPtr PGconn)
                        {-# UNPACK #-} !(MVar NoticeBuffer)
+                       {-# UNPACK #-} !(MVar ()) -- ^ This MVar is filled finishonly once the connection is fully closed (@PQfinish()@ completed on it). See comment in `Database.PostgreSQL.LibPQ.finish`.
 
 instance Eq Connection where
-    (Conn c _) == (Conn d _) = c == d
-    (Conn c _) /= (Conn d _) = c /= d
+    (Conn c _ _) == (Conn d _ _) = c == d
+    (Conn c _ _) /= (Conn d _ _) = c /= d
 
 withConn :: Connection
          -> (Ptr PGconn -> IO b)
          -> IO b
-withConn (Conn !fp _) f = withForeignPtr fp f
+withConn (Conn !fp _ _) f = withForeignPtr fp f
 {-# INLINE withConn #-}
 
 data PGconn


### PR DESCRIPTION
Until now, finish only scheduled the connection to be closed,
resulting in connection existing even after `finish`
(and thus, after higher-level functions like `postgresql-simple`'s `close`).

Beyond incontrollable resource usage, this could also lead to segfaults
if the user employed any libpq functionality that uses Haskell callbacks,
for example "Notice Processing"
(https://www.postgresql.org/docs/14/libpq-notice-processing.html).

Giving a Haskell callback to libpq usually involves code of shape:

    fp <- createFunctionPointer ... -- function that accepts a PGConn
    -- pass fp to libpq
    (LibPQ.finish connection) `finally` (freeHaskellFunPtr fp)

It is critical that the function pointer `fp` and related resources
get freed only _after_ they are last called by libpq.

But the delayed nature of `finish` so far did not provide this guarantee:
The `(LibPQ.finish connection) `finally` (freeHaskellFunPtr fp)` from the
example wouldn't actually ensure that `finish` "finishes" anything
before the `finally` and the freeing happen, thus leading to segfaults
when libpq called into already-freed function pointers.

This commit fixes it by making `finish` block on an MVar that is put
only after `PQFinish` was actually called.