### PR TITLE
Avoid copies when passing binary parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Avoid copies when passing binary parameters
+
 0.9.4.3
 -------
 

--- a/src/Database/PostgreSQL/LibPQ.hsc
+++ b/src/Database/PostgreSQL/LibPQ.hsc
@@ -759,9 +759,8 @@ withParams params action =
                     withArray formats $ \fs ->
                         action n ts vs ls fs
   where
-    (oids, values, lengths, formats) =
+    (oids, values, c_lengths, formats) =
         foldl' accum ([],[],[],[]) $ reverse params
-    !c_lengths = map toEnum lengths :: [CInt]
     !n = toEnum $ length params
 
     accum (!a,!b,!c,!d) Nothing = ( invalidOid:a
@@ -771,7 +770,7 @@ withParams params action =
                                   )
     accum (!a,!b,!c,!d) (Just (t,v,f)) = ( t:a
                                          , (Just v):b
-                                         , (B.length v):c
+                                         , (toEnum $ B.length v):c
                                          , (toEnum $ fromEnum f):d
                                          )
 
@@ -787,8 +786,7 @@ withParamsPrepared params action =
                 withArray formats $ \fs ->
                     action n vs ls fs
   where
-    (values, lengths, formats) = foldl' accum ([],[],[]) $ reverse params
-    !c_lengths = map toEnum lengths :: [CInt]
+    (values, c_lengths, formats) = foldl' accum ([],[],[]) $ reverse params
     !n = toEnum $ length params
 
     accum (!a,!b,!c) Nothing       = ( Nothing:a
@@ -796,7 +794,7 @@ withParamsPrepared params action =
                                      , 0:c
                                      )
     accum (!a,!b,!c) (Just (v, f)) = ( (Just v):a
-                                     , (B.length v):b
+                                     , (toEnum $ B.length v):b
                                      , (toEnum $ fromEnum f):c
                                      )
 

--- a/src/Database/PostgreSQL/LibPQ.hsc
+++ b/src/Database/PostgreSQL/LibPQ.hsc
@@ -756,12 +756,11 @@ withParams params action =
         withMany (maybeWith B.useAsCString) values $ \c_values ->
             withArray c_values $ \vs ->
                 withArray c_lengths $ \ls ->
-                    withArray formats $ \fs ->
-                        action n ts vs ls fs
+                    withArrayLen formats $ \n fs ->
+                        action (toEnum n) ts vs ls fs
   where
     (oids, values, c_lengths, formats) =
         foldl' accum ([],[],[],[]) $ reverse params
-    !n = toEnum $ length params
 
     accum (!a,!b,!c,!d) Nothing = ( invalidOid:a
                                   , Nothing:b
@@ -783,11 +782,10 @@ withParamsPrepared params action =
     withMany (maybeWith B.useAsCString) values $ \c_values ->
         withArray c_values $ \vs ->
             withArray c_lengths $ \ls ->
-                withArray formats $ \fs ->
-                    action n vs ls fs
+                withArrayLen formats $ \n fs ->
+                    action (toEnum n) vs ls fs
   where
     (values, c_lengths, formats) = foldl' accum ([],[],[]) $ reverse params
-    !n = toEnum $ length params
 
     accum (!a,!b,!c) Nothing       = ( Nothing:a
                                      , 0:b


### PR DESCRIPTION
Currently, the library copies every input parameter when passing it to libpq via `Data.ByteString.useAsCString`. This PR avoids those copies for the case of binary parameters, by using `Data.ByteString.Unsafe.unsafeUseAsCString`.

I claim that this is safe because:
- libpq doesn't require binary parameters to be zero-terminated, they are passed with length
- libpq treats parameter input as read-only
- `ByteString` uses pinned memory

There are a few preparatory commits to factor out duplicate code to `withParams`, and to avoid a bit of unnecessary work there.

Context is https://github.com/PostgREST/postgrest/issues/2261. We see significant decrease of memory use with this change: https://github.com/PostgREST/postgrest/pull/2349