### PR TITLE
Enable build for GHC 9.4.2

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.13.20211111
+# version: 0.15.20220826
 #
-# REGENDATA ("0.13.20211111",["github","postgresql-libpq.cabal"])
+# REGENDATA ("0.15.20220826",["github","postgresql-libpq.cabal"])
 #
 name: Haskell-CI
 on:
@@ -23,7 +23,7 @@ on:
 jobs:
   linux:
     name: Haskell-CI - Linux - ${{ matrix.compiler }}
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     timeout-minutes:
       60
     container:
@@ -38,9 +38,9 @@ jobs:
     strategy:
       matrix:
         include:
-          - compiler: ghc-9.2.1
+          - compiler: ghc-9.2.4
             compilerKind: ghc
-            compilerVersion: 9.2.1
+            compilerVersion: 9.2.4
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.0.1
@@ -116,18 +116,18 @@ jobs:
           apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5
           if [ "${{ matrix.setup-method }}" = ghcup ]; then
             mkdir -p "$HOME/.ghcup/bin"
-            curl -sL https://downloads.haskell.org/ghcup/0.1.17.3/x86_64-linux-ghcup-0.1.17.3 > "$HOME/.ghcup/bin/ghcup"
+            curl -sL https://downloads.haskell.org/ghcup/0.1.18.0/x86_64-linux-ghcup-0.1.18.0 > "$HOME/.ghcup/bin/ghcup"
             chmod a+x "$HOME/.ghcup/bin/ghcup"
-            "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER"
-            "$HOME/.ghcup/bin/ghcup" install cabal 3.6.2.0
+            "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
+            "$HOME/.ghcup/bin/ghcup" install cabal 3.6.2.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
           else
             apt-add-repository -y 'ppa:hvr/ghc'
             apt-get update
             apt-get install -y "$HCNAME"
             mkdir -p "$HOME/.ghcup/bin"
-            curl -sL https://downloads.haskell.org/ghcup/0.1.17.3/x86_64-linux-ghcup-0.1.17.3 > "$HOME/.ghcup/bin/ghcup"
+            curl -sL https://downloads.haskell.org/ghcup/0.1.18.0/x86_64-linux-ghcup-0.1.18.0 > "$HOME/.ghcup/bin/ghcup"
             chmod a+x "$HOME/.ghcup/bin/ghcup"
-            "$HOME/.ghcup/bin/ghcup" install cabal 3.6.2.0
+            "$HOME/.ghcup/bin/ghcup" install cabal 3.6.2.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
           fi
         env:
           HCKIND: ${{ matrix.compilerKind }}
@@ -270,7 +270,7 @@ jobs:
           ${CABAL} -vnormal check
       - name: haddock
         run: |
-          $CABAL v2-haddock $ARG_COMPILER --with-haddock $HADDOCK $ARG_TESTS $ARG_BENCH all
+          $CABAL v2-haddock --haddock-all $ARG_COMPILER --with-haddock $HADDOCK $ARG_TESTS $ARG_BENCH all
       - name: unconstrained build
         run: |
           rm -f cabal.project.local

--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -38,6 +38,11 @@ jobs:
     strategy:
       matrix:
         include:
+          - compiler: ghc-9.4.2
+            compilerKind: ghc
+            compilerVersion: 9.4.2
+            setup-method: ghcup
+            allow-failure: false
           - compiler: ghc-9.2.4
             compilerKind: ghc
             compilerVersion: 9.2.4

--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -275,7 +275,7 @@ jobs:
           ${CABAL} -vnormal check
       - name: haddock
         run: |
-          $CABAL v2-haddock --haddock-all $ARG_COMPILER --with-haddock $HADDOCK $ARG_TESTS $ARG_BENCH all
+          $CABAL v2-haddock $ARG_COMPILER --with-haddock $HADDOCK $ARG_TESTS $ARG_BENCH all
       - name: unconstrained build
         run: |
           rm -f cabal.project.local

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -3,3 +3,5 @@ postgresql:         True
 
 -- due build-type: Custom
 test-output-direct: False
+
+haddock-components: libs

--- a/postgresql-libpq.cabal
+++ b/postgresql-libpq.cabal
@@ -39,13 +39,14 @@ tested-with:
    || ==8.10.7
    || ==9.0.1
    || ==9.2.4
+   || ==9.4.2
 
 extra-source-files: CHANGELOG.md
 
 custom-setup
   setup-depends:
       base   >=4.3  && <5
-    , Cabal  >=1.10 && <3.7
+    , Cabal  >=1.10 && <3.9
 
 -- If true,  use pkg-config,  otherwise use the pg_config based build
 -- configuration
@@ -64,7 +65,7 @@ library
 
   other-modules:    Database.PostgreSQL.LibPQ.Compat
   build-depends:
-      base        >=4.3     && <4.17
+      base        >=4.3     && <4.18
     , bytestring  >=0.9.1.0 && <0.12
 
   if !os(windows)

--- a/postgresql-libpq.cabal
+++ b/postgresql-libpq.cabal
@@ -38,7 +38,7 @@ tested-with:
    || ==8.8.4
    || ==8.10.7
    || ==9.0.1
-   || ==9.2.1
+   || ==9.2.4
 
 extra-source-files: CHANGELOG.md
 


### PR DESCRIPTION
- Bump GHC 9.2 version to 9.2.4
- Enable build for GHC 9.4.2
