### PR TITLE
withParams*: drop redundant call to 'length' by using 'withArrayLen'

### DIFF
--- a/src/Database/PostgreSQL/LibPQ.hsc
+++ b/src/Database/PostgreSQL/LibPQ.hsc
@@ -754,14 +754,11 @@ withParams params action =
         withMany (maybeWith B.useAsCString) values $ \c_values ->
             withArray c_values $ \vs ->
                 withArray c_lengths $ \ls ->
-                    withArray formats $ \fs ->
-                        action n ts vs ls fs
+                    withArrayLen formats $ \n fs ->
+                        action (intToCInt n) ts vs ls fs
   where
     AccumParams oids values c_lengths formats =
         foldr accum (AccumParams [] [] [] []) params
-
-    n :: CInt
-    !n = intToCInt $ length params
 
     accum :: Maybe (Oid, B.ByteString, Format) -> AccumParams -> AccumParams
     accum Nothing ~(AccumParams a b c d) =
@@ -790,14 +787,11 @@ withParamsPrepared params action =
     withMany (maybeWith B.useAsCString) values $ \c_values ->
         withArray c_values $ \vs ->
             withArray c_lengths $ \ls ->
-                withArray formats $ \fs ->
-                    action n vs ls fs
+                withArrayLen formats $ \n fs ->
+                    action (intToCInt n) vs ls fs
   where
     AccumPrepParams values c_lengths formats =
         foldr accum (AccumPrepParams [] [] []) params
-
-    n :: CInt
-    n = intToCInt $ length params
 
     accum :: Maybe (B.ByteString ,Format) -> AccumPrepParams -> AccumPrepParams
     accum Nothing ~(AccumPrepParams a b c) =


### PR DESCRIPTION
This is the other left-over change from #22.

I'm a bit unsure whether this is a net win: It saves us one out of several redundant list length computing the parameter length list and a few lines of code, at the expense of arbitrarily breaking symmetry between the different equally long lists.

The nicer way to optimize this might be if `Foreign.Marshal` exposed something like `unsafeWithArray len vals action`.