### PR TITLE
Support GHC 9.8.1

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -38,14 +38,19 @@ jobs:
     strategy:
       matrix:
         include:
+          - compiler: ghc-9.8.1
+            compilerKind: ghc
+            compilerVersion: 9.8.1
+            setup-method: ghcup
+            allow-failure: false
           - compiler: ghc-9.6.1
             compilerKind: ghc
             compilerVersion: 9.6.1
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-9.4.4
+          - compiler: ghc-9.4.7
             compilerKind: ghc
-            compilerVersion: 9.4.4
+            compilerVersion: 9.4.7
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.2.7

--- a/postgresql-libpq.cabal
+++ b/postgresql-libpq.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               postgresql-libpq
-version:            0.10.0.0
+version:            0.10.0.1
 synopsis:           low-level binding to libpq
 description:
   This is a binding to libpq: the C application
@@ -24,7 +24,7 @@ category:           Database
 build-type:         Custom
 extra-source-files: cbits/hs-libpq.h
 tested-with:
-  GHC ==8.6.5 || ==8.8.4 || ==8.10.7 || ==9.0.2 || ==9.2.7 || ==9.4.4 || ==9.6.1
+  GHC ==8.6.5 || ==8.8.4 || ==8.10.7 || ==9.0.2 || ==9.2.8 || ==9.4.7 || ==9.6.1 || ==9.8.1
 
 extra-source-files: CHANGELOG.md
 
@@ -67,8 +67,8 @@ library
     Database.PostgreSQL.LibPQ.Oid
 
   build-depends:
-    , base        >=4.12.0.0 && <4.19
-    , bytestring  >=0.10.8.2 && <0.12
+    , base        >=4.12.0.0 && <4.20
+    , bytestring  >=0.10.8.2 && <0.13
 
   if !os(windows)
     build-depends: unix >=2.7.2.2 && <2.9


### PR DESCRIPTION
This PR bumps the bounds for supporting bytestring 0.12, base 4.19 and GHC 9.8.1