### PR TITLE
Add pipeline mode API with cabal flag

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -27,7 +27,7 @@ jobs:
     timeout-minutes:
       60
     container:
-      image: buildpack-deps:bionic
+      image: buildpack-deps:jammy
     services:
       postgres:
         image: postgres:14

--- a/postgresql-libpq.cabal
+++ b/postgresql-libpq.cabal
@@ -39,6 +39,12 @@ flag use-pkg-config
   default: False
   manual:  True
 
+-- If true,  use libpq bindings for Pipeline Mode,  otherwise throw
+-- errors on usage. It requires libpq >=14
+flag enable-pipeline-mode
+  default: True
+  manual:  False
+
 library
   default-language:   Haskell2010
   hs-source-dirs:     src
@@ -75,6 +81,9 @@ library
 
   if os(windows)
     build-depends: Win32 >=2.2.0.2 && <2.14
+
+  if flag(enable-pipeline-mode)
+    cpp-options: -DHASKELL_LIBPQ_PIPELINE_MODE
 
   if flag(use-pkg-config)
     pkgconfig-depends: libpq >=10.22

--- a/src/Database/PostgreSQL/LibPQ.hs
+++ b/src/Database/PostgreSQL/LibPQ.hs
@@ -171,6 +171,15 @@ module Database.PostgreSQL.LibPQ
     , FlushStatus(..)
     , flush
 
+    -- * Pipeline Mode
+    -- $pipeline
+    , PipelineStatus(..)
+    , pipelineStatus
+    , enterPipelineMode
+    , exitPipelineMode
+    , pipelineSync
+    , sendFlushRequest
+
     -- * Cancelling Queries in Progress
     -- $cancel
     , Cancel
@@ -1635,6 +1644,36 @@ flush connection =
          0 -> return FlushOk
          1 -> return FlushWriting
          _ -> return FlushFailed
+
+
+pipelineStatus :: Connection
+               -> IO PipelineStatus
+pipelineStatus connection = do
+    stat <- withConn connection c_PQpipelineStatus
+    maybe
+      (fail $ "Unknown pipeline status " ++ show stat)
+      return
+      (fromCInt stat)
+
+enterPipelineMode :: Connection
+                  -> IO Bool
+enterPipelineMode connection =
+    enumFromConn connection c_PQenterPipelineMode
+
+exitPipelineMode :: Connection
+                 -> IO Bool
+exitPipelineMode connection =
+    enumFromConn connection c_PQexitPipelineMode
+
+pipelineSync :: Connection
+             -> IO Bool
+pipelineSync connection =
+    enumFromConn connection c_PQpipelineSync
+
+sendFlushRequest :: Connection
+                 -> IO Bool
+sendFlushRequest connection =
+    enumFromConn connection c_PQsendFlushRequest
 
 
 -- $cancel

--- a/src/Database/PostgreSQL/LibPQ/Compat.hs
+++ b/src/Database/PostgreSQL/LibPQ/Compat.hs
@@ -25,3 +25,13 @@ mkPS fp off len = BS (plusForeignPtr fp off) len
 mkPS fp off len = PS fp off len
 #endif
 {-# INLINE mkPS #-}
+
+-- | Shows that compiled code was linked with LibPQ supporting Pipeline Mode.
+-- LibPQ version >= 14.
+isEnabledPipeline :: Bool
+#if HASKELL_LIBPQ_PIPELINE_MODE
+isEnabledPipeline = True
+#else
+isEnabledPipeline = False
+#endif
+{-# INLINE isEnabledPipeline #-}

--- a/src/Database/PostgreSQL/LibPQ/Enums.hsc
+++ b/src/Database/PostgreSQL/LibPQ/Enums.hsc
@@ -65,8 +65,10 @@ instance FromCInt ExecStatus where
     fromCInt (#const PGRES_NONFATAL_ERROR)   = Just NonfatalError
     fromCInt (#const PGRES_FATAL_ERROR)      = Just FatalError
     fromCInt (#const PGRES_SINGLE_TUPLE)     = Just SingleTuple
+    #if HASKELL_LIBPQ_PIPELINE_MODE
     fromCInt (#const PGRES_PIPELINE_SYNC)    = Just PipelineSync
     fromCInt (#const PGRES_PIPELINE_ABORTED) = Just PipelineAbort
+    #endif
     fromCInt _ = Nothing
 
 instance ToCInt ExecStatus where
@@ -80,8 +82,16 @@ instance ToCInt ExecStatus where
     toCInt NonfatalError = (#const PGRES_NONFATAL_ERROR)
     toCInt FatalError    = (#const PGRES_FATAL_ERROR)
     toCInt SingleTuple   = (#const PGRES_SINGLE_TUPLE)
+    #if HASKELL_LIBPQ_PIPELINE_MODE
     toCInt PipelineSync  = (#const PGRES_PIPELINE_SYNC)
+    #else
+    toCInt PipelineSync  = error "pipeline mode is disabled"
+    #endif
+    #if HASKELL_LIBPQ_PIPELINE_MODE
     toCInt PipelineAbort = (#const PGRES_PIPELINE_ABORTED)
+    #else
+    toCInt PipelineSync  = error "pipeline mode is disabled"
+    #endif
 
 
 data FieldCode
@@ -245,7 +255,7 @@ instance FromCInt ConnStatus where
     fromCInt (#const CONNECTION_SSL_STARTUP)       = return ConnectionSSLStartup
     -- fromCInt (#const CONNECTION_NEEDED)         = return ConnectionNeeded
     fromCInt _ = Nothing
-    
+
 
 data TransactionStatus
     = TransIdle    -- ^ currently idle
@@ -288,9 +298,11 @@ data PipelineStatus
   deriving (Eq, Show)
 
 instance FromCInt PipelineStatus where
+    #if HASKELL_LIBPQ_PIPELINE_MODE
     fromCInt (#const PQ_PIPELINE_ON) = return PipelineOn
     fromCInt (#const PQ_PIPELINE_OFF) = return PipelineOff
     fromCInt (#const PQ_PIPELINE_ABORTED) = return PipelineAborted
+    #endif
     fromCInt _ = Nothing
 
 -------------------------------------------------------------------------------

--- a/src/Database/PostgreSQL/LibPQ/FFI.hs
+++ b/src/Database/PostgreSQL/LibPQ/FFI.hs
@@ -302,6 +302,21 @@ foreign import capi        "hs-libpq.h &PQfreemem"
 foreign import capi        "hs-libpq.h PQfreemem"
     c_PQfreemem :: Ptr a -> IO ()
 
+foreign import capi        "hs-libpq.h PQpipelineStatus"
+    c_PQpipelineStatus :: Ptr PGconn -> IO CInt
+
+foreign import capi        "hs-libpq.h PQenterPipelineMode"
+    c_PQenterPipelineMode :: Ptr PGconn -> IO CInt
+
+foreign import capi        "hs-libpq.h PQexitPipelineMode"
+    c_PQexitPipelineMode :: Ptr PGconn -> IO CInt
+
+foreign import capi        "hs-libpq.h PQpipelineSync"
+    c_PQpipelineSync :: Ptr PGconn -> IO CInt
+
+foreign import capi        "hs-libpq.h PQsendFlushRequest"
+    c_PQsendFlushRequest :: Ptr PGconn -> IO CInt
+
 -------------------------------------------------------------------------------
 -- FFI imports: noticebuffers
 -------------------------------------------------------------------------------

--- a/src/Database/PostgreSQL/LibPQ/FFI.hs
+++ b/src/Database/PostgreSQL/LibPQ/FFI.hs
@@ -118,7 +118,7 @@ foreign import capi        "hs-libpq.h PQputCopyData"
 
 foreign import capi        "hs-libpq.h PQputCopyEnd"
     c_PQputCopyEnd :: Ptr PGconn -> CString -> IO CInt
- 
+
 -- TODO: GHC #22043
 foreign import ccall       "hs-libpq.h PQgetCopyData"
     c_PQgetCopyData :: Ptr PGconn -> Ptr (Ptr Word8) -> CInt -> IO CInt
@@ -302,20 +302,25 @@ foreign import capi        "hs-libpq.h &PQfreemem"
 foreign import capi        "hs-libpq.h PQfreemem"
     c_PQfreemem :: Ptr a -> IO ()
 
-foreign import capi        "hs-libpq.h PQpipelineStatus"
-    c_PQpipelineStatus :: Ptr PGconn -> IO CInt
+-- requires libpq >= 14
+foreign import capi         "hs-libpq.h PQpipelineStatus"
+    c_PQpipelineStatus      :: Ptr PGconn -> IO CInt
 
-foreign import capi        "hs-libpq.h PQenterPipelineMode"
-    c_PQenterPipelineMode :: Ptr PGconn -> IO CInt
+-- requires libpq >= 14
+foreign import capi         "hs-libpq.h PQenterPipelineMode"
+    c_PQenterPipelineMode   :: Ptr PGconn -> IO CInt
 
-foreign import capi        "hs-libpq.h PQexitPipelineMode"
-    c_PQexitPipelineMode :: Ptr PGconn -> IO CInt
+-- requires libpq >= 14
+foreign import capi         "hs-libpq.h PQexitPipelineMode"
+    c_PQexitPipelineMode    :: Ptr PGconn -> IO CInt
 
-foreign import capi        "hs-libpq.h PQpipelineSync"
-    c_PQpipelineSync :: Ptr PGconn -> IO CInt
+-- requires libpq >= 14
+foreign import capi         "hs-libpq.h PQpipelineSync"
+    c_PQpipelineSync        :: Ptr PGconn -> IO CInt
 
-foreign import capi        "hs-libpq.h PQsendFlushRequest"
-    c_PQsendFlushRequest :: Ptr PGconn -> IO CInt
+-- requires libpq >= 14
+foreign import capi         "hs-libpq.h PQsendFlushRequest"
+    c_PQsendFlushRequest    :: Ptr PGconn -> IO CInt
 
 -------------------------------------------------------------------------------
 -- FFI imports: noticebuffers

--- a/test/Smoke.hs
+++ b/test/Smoke.hs
@@ -1,6 +1,6 @@
 module Main (main) where
 
-import Control.Monad (unless)
+import Control.Monad (unless, when)
 import Database.PostgreSQL.LibPQ
 import Data.Foldable (toList)
 import System.Environment (getEnvironment)
@@ -13,7 +13,7 @@ main = do
     libpqVersion >>= print
     withConnstring $ \connstring -> do
         smoke connstring
-        testPipeline connstring
+        when isEnabledPipeline $ testPipeline connstring
 
 withConnstring :: (BS8.ByteString -> IO ()) -> IO ()
 withConnstring kont = do
@@ -50,7 +50,6 @@ smoke connstring = do
     transactionStatus conn >>= print
     protocolVersion conn   >>= print
     serverVersion conn     >>= print
-    pipelineStatus conn    >>= print
 
     s <- status conn
     unless (s == ConnectionOk) exitFailure
@@ -60,6 +59,8 @@ smoke connstring = do
 testPipeline :: BS8.ByteString -> IO ()
 testPipeline connstring = do
     conn <- connectdb connstring
+
+    pipelineStatus conn    >>= print
 
     setnonblocking conn True `shouldReturn` True
     enterPipelineMode conn `shouldReturn` True

--- a/test/Smoke.hs
+++ b/test/Smoke.hs
@@ -48,6 +48,7 @@ smoke connstring = do
     transactionStatus conn >>= print
     protocolVersion conn   >>= print
     serverVersion conn     >>= print
+    pipelineStatus conn    >>= print
 
     s <- status conn
     unless (s == ConnectionOk) exitFailure


### PR DESCRIPTION
It is based on [existing PR](https://github.com/haskellari/postgresql-libpq/pull/42) with origin commits preserved.

Also, according to the [comment](https://github.com/haskellari/postgresql-libpq/pull/42#issuecomment-1728095534), it implies that the default is to enable the new functions.

_P.S. Origin commits by @robx contain changes to CI. I am not sure what is right, so, I left them as is. Let me known if some changes are required._