### PR TITLE
fix: add missing `extra-libraries` dependency in `postgresql-libpq-configure.cabal`

### DIFF
--- a/postgresql-libpq-configure/postgresql-libpq-configure.cabal
+++ b/postgresql-libpq-configure/postgresql-libpq-configure.cabal
@@ -38,6 +38,7 @@ extra-source-files:
 
 library
   default-language: Haskell2010
+  extra-libraries:  pq
   build-depends:    base <5
 
 source-repository head


### PR DESCRIPTION
I encountered the following problems.

[Build failure: `haskellPackages.postgresql-libpq-configure` · Issue #370138 · NixOS/nixpkgs](https://github.com/NixOS/nixpkgs/issues/370138)

Since the missing dependencies were the cause,
the previously existing dependency descriptions were minimally restored to the cabal file.

This change restores `librarySystemDepends` as follows.

```
$ cabal2nix postgresql-libpq-configure/postgresql-libpq-configure.cabal
```

``` nix
{ mkDerivation, base, lib, postgresql }:
mkDerivation {
  pname = "postgresql-libpq-configure";
  version = "0.11";
  sha256 = "1n5jjnnflh2ldqvcs44al572240s2435bh5m761hrpbmai5y6kwd";
  libraryHaskellDepends = [ base ];
  librarySystemDepends = [ postgresql ];
  doHaddock = false;
  homepage = "https://github.com/haskellari/postgresql-libpq";
  description = "low-level binding to libpq: configure based provider";
  license = lib.licenses.bsd3;
}
```

The following flake file was used to build the environment for checking builds in Nix.

``` nix
{
  nixConfig = {
    extra-substituters = [ "https://cache.nixos.org/" "https://cache.iog.io" ];
    extra-trusted-public-keys =
      [ "hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=" ];
    allow-import-from-derivation = "true";
  };

  inputs = {
    haskellNix.url = "github:input-output-hk/haskell.nix";
    nixpkgs.follows = "haskellNix/nixpkgs-unstable";
    flake-utils.url = "github:numtide/flake-utils";
  };

  outputs = { self, nixpkgs, flake-utils, haskellNix, }:
    let systems = [ "x86_64-linux" ];
    in flake-utils.lib.eachSystem systems (system:
      let
        pkgs = import nixpkgs {
          inherit system overlays;
          inherit (haskellNix) config;
        };
        hspkgs = pkgs.haskell.packages;
        overlays = [
          haskellNix.overlay
          (final: prev: {
            project = final.haskell-nix.project' {
              src = ./.;
              compiler-nix-name = "ghc966";
              shell = { tools = { cabal = "latest"; }; };
            };
          })
        ];
        flake = pkgs.project.flake { };
      in flake);
}
```
